### PR TITLE
Define HydratedPost type for hydrated queries

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,6 +22,15 @@ export type Post = {
   clusterSize: number | null;
 };
 
+/**
+ * Server-side hydrated posts share the same core shape as client posts.
+ * The difference is that `embed` is guaranteed to align with the hover
+ * player metadata we derive during hydration.
+ */
+export type HydratedPost = Post & {
+  embed?: { type: "youtube" | "x" | "mp4"; url: string };
+};
+
 export type TimeRange = "3h" | "6h" | "24h" | "1w";
 
 export const ALL_TIME_RANGES: TimeRange[] = ["3h", "6h", "24h", "1w"];


### PR DESCRIPTION
## Summary
- add a HydratedPost type that mirrors the hydrated post shape and refines the embed metadata

## Testing
- pnpm lint *(fails: existing lint violations around `any` usage and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ea53e8d08331949c842b2ba5a38b