### PR TITLE
Fix post detail image enrichment effect deps

### DIFF
--- a/components/post-detail.tsx
+++ b/components/post-detail.tsx
@@ -393,7 +393,7 @@ export function PostDetail({ post, inDialog }: PostDetailProps) {
     return () => {
       observer.disconnect();
     };
-  }, [post.id, post.imageEnrichmentUpdatedAt]);
+  }, [post.id, post.imageEnrichments, post.imageEnrichmentUpdatedAt]);
 
   // Note: previous dev-only overflow logger and runtime image normalization were removed
   // to reduce complexity. Server-side HTML normalization + CSS handle layout now.


### PR DESCRIPTION
## Summary
- include `post.imageEnrichments` in the image enrichment effect dependency array so the hook covers all referenced values

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e911367483318b7d928251a3eb83