### PR TITLE
Add production log for Clerk publishable key

### DIFF
--- a/components/clerk-provider.tsx
+++ b/components/clerk-provider.tsx
@@ -7,6 +7,15 @@ import {
 } from "@clerk/clerk-react";
 
 const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+if (process.env.NODE_ENV === "production") {
+  const redactedKey = publishableKey
+    ? `${publishableKey.slice(0, 6)}… (len=${publishableKey.length})`
+    : "<undefined>";
+  console.log(
+    `[Clerk] NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${redactedKey}. NODE_ENV=${process.env.NODE_ENV}`,
+  );
+}
 let missingKeyWarningLogged = false;
 
 export function ClientClerkProvider({ children }: PropsWithChildren): JSX.Element {


### PR DESCRIPTION
## Summary
- log a sanitized NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY value during production builds to aid CI debugging

## Testing
- pnpm lint *(fails: numerous pre-existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9d0bcd0083318b266cd7cfcc9071