### PR TITLE
Sync infinite post list state to shared post cache

### DIFF
--- a/components/infinite-post-list.tsx
+++ b/components/infinite-post-list.tsx
@@ -831,6 +831,9 @@ export default function InfinitePostList({
 
   // --- State & Refs ---
   const [posts, setPosts] = useState<Post[]>(initialPosts);
+  useEffect(() => {
+    addPosts(posts);
+  }, [addPosts, posts]);
   const [page, setPage] = useState(initialPage);
   const [hasMore, setHasMore] = useState(true);
   // --- Live postsRef for up-to-date list ---


### PR DESCRIPTION
## Summary
- ensure the infinite post list pushes its local posts state into the shared cache on mount and whenever it updates

## Testing
- `pnpm lint` *(fails: existing lint violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cadb004e7c83319fc41b1b73734932