### PR TITLE
Align read marker storage key and types

### DIFF
--- a/components/post-card.tsx
+++ b/components/post-card.tsx
@@ -276,6 +276,7 @@ interface PostCardProps {
   storageKeyPrefix?: string;
   isNew?: boolean;
   isPriority?: boolean;
+  isRead?: boolean;
 }
 
 const communityColors: Record<string, string> = {
@@ -290,7 +291,7 @@ const communityColors: Record<string, string> = {
 };
 
 export const PostCard = React.memo(
-  function PostCard({ postId, layout, page, storageKeyPrefix = "", isNew = false, isPriority = false }: PostCardProps) {
+  function PostCard({ postId, layout, page, storageKeyPrefix = "", isNew = false, isPriority = false, isRead = false }: PostCardProps) {
     const { openModal } = useModal();
     const { postIds } = usePostList();
     const { posts } = usePostCache();
@@ -648,7 +649,8 @@ export const PostCard = React.memo(
             id={`post-${post.id}`}
             href={`/posts/${post.id}`}
             prefetch={!isMobile}
-            className={`block ${isNew ? 'fade-in' : ''}`}
+            className={cn(`block ${isNew ? 'fade-in' : ''}`, isRead && 'is-read')}
+            data-read={isRead ? '1' : undefined}
             onClick={handleClick}
           >
             <Card className="rounded-none shadow-none border-x-0 border-b md:rounded-lg md:shadow-sm md:border hover:shadow-none md:hover:shadow-md transition-shadow cursor-pointer">
@@ -662,7 +664,8 @@ export const PostCard = React.memo(
             href={post.url}
             target="_blank"
             rel="noopener noreferrer"
-            className={`block ${isNew ? 'fade-in' : ''}`}
+            className={cn(`block ${isNew ? 'fade-in' : ''}`, isRead && 'is-read')}
+            data-read={isRead ? '1' : undefined}
             onClick={() => markPostAsRead({ id: post.id, title: post.title })}
           >
             <Card className="rounded-none shadow-none border-x-0 border-b md:rounded-lg md:shadow-sm md:border hover:shadow-none md:hover:shadow-md transition-shadow cursor-pointer">


### PR DESCRIPTION
## Summary
- update the infinite post list to read the v2 localStorage key used by the read marker writer
- type the parsed read marker payload as a record of timestamp/title entries before creating the read id set
- pass the read marker set through the list virtualizer so each PostCard receives a defined `isRead` flag

## Testing
- `pnpm lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cae18af080833182650c543d8b9188