### PR TITLE
Fix category sidebar positioning

### DIFF
--- a/app/[category]/layout.tsx
+++ b/app/[category]/layout.tsx
@@ -11,9 +11,9 @@ export default function CategoryLayout({
     <div className="min-h-screen bg-gray-50">
       <Header />
       <main className="w-full max-w-screen-xl mx-auto px-0 md:px-4 py-6">
-        <div className="flex items-start xl:gap-6">
+        <div className="flex xl:gap-6">
           <div className="hidden xl:block w-80 shrink-0">
-            <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-scroll [scrollbar-gutter:stable_both-edges] transform-gpu will-change-transform [contain:layout_paint]">
+            <div className="sticky top-24 transform-gpu will-change-transform [contain:layout_paint]">
               <Sidebar />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- keep the category page sidebar container sticky without its own scroll so it stays visible while browsing long lists

## Testing
- pnpm lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cf16b5a9e883319b11ac0b4b40c0cb