### PR TITLE
Align category sidebar scroll behavior with home page

### DIFF
--- a/app/[category]/layout.tsx
+++ b/app/[category]/layout.tsx
@@ -13,7 +13,7 @@ export default function CategoryLayout({
       <main className="w-full max-w-screen-xl mx-auto px-0 md:px-4 py-6">
         <div className="flex xl:gap-6">
           <div className="hidden xl:block w-80 shrink-0">
-            <div className="sticky top-24 transform-gpu will-change-transform [contain:layout_paint]">
+            <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-scroll [scrollbar-gutter:stable_both-edges] transform-gpu will-change-transform [contain:layout_paint]">
               <Sidebar />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add the overflow and max height constraints to the category layout sidebar wrapper so it scrolls identically to the home page

## Testing
- pnpm lint *(fails: numerous pre-existing lint errors about `any` usage, unused vars, and Next.js warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68cf232e7580833198e88eb97ab2f6f9