### PR TITLE
Optimize mobile spacing for infinite feed

### DIFF
--- a/components/post-card.tsx
+++ b/components/post-card.tsx
@@ -572,7 +572,7 @@ export const PostCard = React.memo(
               {(post.thumbnail || post.hoverPlayerUrl) ? (
                 <HoverCard openDelay={1000}>
                   <HoverCardTrigger asChild>
-                    <div className="relative w-full aspect-[3/2] rounded-lg overflow-hidden">
+                    <div className="relative w-full aspect-[3/2] overflow-hidden md:rounded-lg">
                       <InlinePreviewMedia
                         post={post}
                         priority={isPriority}
@@ -679,7 +679,7 @@ export const PostCard = React.memo(
         : (
           <CardContent className="p-3 md:p-4">
             <div className="space-y-3">
-              <div className="relative w-full aspect-[3/2] rounded-lg overflow-hidden">
+              <div className="relative w-full aspect-[3/2] overflow-hidden md:rounded-lg">
                 <InlinePreviewMedia
                   post={post}
                   priority={isPriority}


### PR DESCRIPTION
## Summary
- dynamically compute the virtualized grid gap so xs viewports render edge-to-edge without spacing while keeping wider layouts unchanged
- update the infinite list row estimates and styling to stay in sync with the responsive gap adjustments and remove mobile corner rounding from the restore glow effect
- drop rounded corners on mobile post thumbnails so images fill the available width

## Testing
- pnpm lint *(fails: existing lint violations around `any` types, unused vars, and Next.js warnings that predate this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc10dbb0883318fb80d2b870fb9dc