### PR TITLE
Remove edge-to-edge mobile styling for category feed

### DIFF
--- a/app/[category]/layout.tsx
+++ b/app/[category]/layout.tsx
@@ -10,7 +10,7 @@ export default function CategoryLayout({
   return (
     <div className="min-h-screen bg-gray-50">
       <Header />
-      <main className="w-full max-w-screen-xl mx-auto px-0 md:px-4 py-6">
+      <main className="w-full max-w-screen-xl mx-auto px-4 py-6">
         <div className="flex xl:gap-6">
           <div className="hidden xl:block w-80 shrink-0">
             <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-scroll [scrollbar-gutter:stable_both-edges] transform-gpu will-change-transform [contain:layout_paint]">

--- a/components/post-card.tsx
+++ b/components/post-card.tsx
@@ -508,7 +508,7 @@ export const PostCard = React.memo(
       layout === "list"
         ? (
           <CardContent className="flex p-0 h-24">
-            <div className="relative flex-shrink-0 w-16 md:w-20 overflow-hidden md:rounded-l-lg">
+            <div className="relative flex-shrink-0 w-16 md:w-20 overflow-hidden rounded-l-lg">
               <HoverCard openDelay={1000}>
                 <HoverCardTrigger asChild>
                   <InlinePreviewMedia
@@ -590,7 +590,7 @@ export const PostCard = React.memo(
                   alt=""
                   width={300}
                   height={160}
-                  className="w-full aspect-[3/2] object-cover rounded-none md:rounded-lg"
+                  className="w-full aspect-[3/2] object-cover rounded-lg"
                   priority={isPriority}
                   referrerPolicy="no-referrer"
                 />
@@ -629,7 +629,7 @@ export const PostCard = React.memo(
       layout === "list"
         ? (
           <CardContent className="flex p-0 h-24">
-            <div className="relative flex-shrink-0 w-16 md:w-20 overflow-hidden md:rounded-l-lg">
+            <div className="relative flex-shrink-0 w-16 md:w-20 overflow-hidden rounded-l-lg">
               <InlinePreviewMedia
                 post={post}
                 priority={isPriority}
@@ -741,7 +741,7 @@ export const PostCard = React.memo(
             data-read={isRead ? '1' : undefined}
             onClick={handleClick}
           >
-            <Card className="rounded-none shadow-none border-x-0 border-b md:rounded-lg md:shadow-sm md:border hover:shadow-none md:hover:shadow-md transition-shadow cursor-pointer">
+            <Card className="transition-shadow cursor-pointer hover:shadow-md">
               <SignedInCardContent />
             </Card>
           </Link>
@@ -756,7 +756,7 @@ export const PostCard = React.memo(
             data-read={isRead ? '1' : undefined}
             onClick={() => markPostAsRead({ id: post.id, title: post.title, url: post.url })}
           >
-            <Card className="rounded-none shadow-none border-x-0 border-b md:rounded-lg md:shadow-sm md:border hover:shadow-none md:hover:shadow-md transition-shadow cursor-pointer">
+            <Card className="transition-shadow cursor-pointer hover:shadow-md">
               <SignedOutCardContent />
             </Card>
           </a>


### PR DESCRIPTION
## Summary
- apply consistent horizontal padding to the category feed layout so small screens no longer render edge-to-edge
- update post card styling so list cards keep their rounded borders and hover shadow on every breakpoint

## Testing
- `pnpm lint` *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdc5d719c8331b23e37525ae1a537