### PR TITLE
Fix list thumbnail sizing

### DIFF
--- a/components/post-card.tsx
+++ b/components/post-card.tsx
@@ -508,13 +508,13 @@ export const PostCard = React.memo(
       layout === "list"
         ? (
           <CardContent className="flex p-0 h-24">
-            <div className="relative flex-shrink-0 w-16 md:w-20 overflow-hidden rounded-l-lg">
+            <div className="relative flex-shrink-0 w-20 overflow-hidden rounded-l-lg">
               <HoverCard openDelay={1000}>
                 <HoverCardTrigger asChild>
                   <InlinePreviewMedia
                     post={post}
                     priority={isPriority}
-                    sizes="(max-width: 768px) 64px, 80px"
+                    sizes="80px"
                     className="absolute inset-0"
                   />
                 </HoverCardTrigger>
@@ -629,11 +629,11 @@ export const PostCard = React.memo(
       layout === "list"
         ? (
           <CardContent className="flex p-0 h-24">
-            <div className="relative flex-shrink-0 w-16 md:w-20 overflow-hidden rounded-l-lg">
+            <div className="relative flex-shrink-0 w-20 overflow-hidden rounded-l-lg">
               <InlinePreviewMedia
                 post={post}
                 priority={isPriority}
-                sizes="(max-width: 768px) 64px, 80px"
+                sizes="80px"
                 className="absolute inset-0"
               />
             </div>


### PR DESCRIPTION
## Summary
- give list layout thumbnails a consistent fixed width across breakpoints
- request a constant size from InlinePreviewMedia so Next.js picks the right asset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfe59ad27c8331a0ed45b87c0750dd