### PR TITLE
Hide MP4 badge on small screens

### DIFF
--- a/components/post-card.tsx
+++ b/components/post-card.tsx
@@ -454,7 +454,12 @@ export const PostCard = React.memo(
           </span>
         )}
         {post.hoverPlayerKind === 'mp4' && (
-          <Badge variant="secondary" className="bg-gray-100 text-gray-800 border-0">MP4</Badge>
+          <Badge
+            variant="secondary"
+            className="hidden sm:inline-flex bg-gray-100 text-gray-800 border-0"
+          >
+            MP4
+          </Badge>
         )}
         {post.hasX && (
           <span title="X 임베드" className="inline-flex items-center">
@@ -495,7 +500,10 @@ export const PostCard = React.memo(
             </span>
           )}
           {post.hoverPlayerKind === 'mp4' && (
-            <Badge variant="secondary" className="hidden @[12rem]:inline-flex bg-gray-100 text-gray-800 border-0">
+            <Badge
+              variant="secondary"
+              className="hidden sm:@[12rem]:inline-flex bg-gray-100 text-gray-800 border-0"
+            >
               MP4
             </Badge>
           )}


### PR DESCRIPTION
## Summary
- hide the MP4 badge on post cards when the viewport is below the `sm` breakpoint
- adjust list/grid badge styles so the MP4 indicator only appears on small-plus layouts

## Testing
- pnpm lint *(fails: existing lint issues in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe90374c8833180a75166a94ac60c