### PR TITLE
Keep inline video previews alive when offscreen

### DIFF
--- a/lib/post-preview-activation.ts
+++ b/lib/post-preview-activation.ts
@@ -1,0 +1,44 @@
+const activatedPreviews = new Set<string>();
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch {
+      // ignore listener errors to avoid breaking notification chain
+    }
+  }
+}
+
+export function markPostPreviewActivated(id: string): void {
+  if (!id) return;
+  const prevSize = activatedPreviews.size;
+  activatedPreviews.add(id);
+  if (activatedPreviews.size !== prevSize) {
+    notify();
+  }
+}
+
+export function clearPostPreviewActivation(id: string): void {
+  if (!id) return;
+  if (activatedPreviews.delete(id)) {
+    notify();
+  }
+}
+
+export function isPostPreviewActivated(id: string): boolean {
+  if (!id) return false;
+  return activatedPreviews.has(id);
+}
+
+export function subscribeToPreviewActivation(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getActivatedPreviewSnapshot(): string[] {
+  return Array.from(activatedPreviews);
+}

--- a/public/embed/video.html
+++ b/public/embed/video.html
@@ -35,6 +35,30 @@
       } else {
         el.pause();
       }
+
+      const handleMessage = (event) => {
+        if (!event || typeof event.data !== 'object' || event.data === null) return;
+        if (event.origin && event.origin !== window.location.origin) return;
+        const { type } = event.data;
+        if (type === 'pause') {
+          try {
+            el.pause();
+          } catch {
+            /* ignore */
+          }
+        } else if (type === 'play') {
+          try {
+            const maybePromise = el.play();
+            if (maybePromise && typeof maybePromise.catch === 'function') {
+              maybePromise.catch(() => {});
+            }
+          } catch {
+            /* ignore */
+          }
+        }
+      };
+
+      window.addEventListener('message', handleMessage);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- retain inline preview iframes once activated, hide them with CSS when offscreen, and postMessage play/pause events instead of remounting
- persist hover activation state in a shared module and teach the virtualizer to keep recently active rows within range a bit longer
- update the embed shim to listen for play/pause commands without tearing down buffered video state

## Testing
- pnpm lint *(fails: repository already contains many pre-existing lint errors about `any`, unused variables, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68d03614df808331b7bba87383e3c42c