### PR TITLE
Derive virtual list buffers from viewport

### DIFF
--- a/app/(feed)/page.tsx
+++ b/app/(feed)/page.tsx
@@ -143,8 +143,6 @@ export default async function Home() {
                   initialPosts={fresh}
                   jsonBase={`/data/home/v1/${selectedRange}/fresh`}
                   enablePaging={true}
-                  loadAheadRows={1}
-                  virtualOverscan={18}
                 />
               </Suspense>
 

--- a/app/keywords/[keyword]/[[...range]]/KeywordFeed.client.tsx
+++ b/app/keywords/[keyword]/[[...range]]/KeywordFeed.client.tsx
@@ -54,8 +54,6 @@ export default function KeywordFeed({ initialPosts, keyword, initialRange }: Key
         listColumns={viewMode === "grid" ? "3-2-1" : "auto-2"}
         cardLayoutOverride={viewMode === "grid" ? "grid" : "list"}
         threeColAt="xl"
-        loadAheadRows={viewMode === "list" ? 1 : 0}
-        virtualOverscan={viewMode === "list" ? 18 : 10}
         jsonBase={jsonBase}
         range={range as any}
         readFilter={readFilter}

--- a/components/CategoryFeed.client.tsx
+++ b/components/CategoryFeed.client.tsx
@@ -110,8 +110,6 @@ export default function CategoryFeed({
         listColumns={viewMode === "grid" ? "3-2-1" : "auto-2"}
         cardLayoutOverride={viewMode === "grid" ? "grid" : "list"}
         threeColAt="xl"
-        loadAheadRows={viewMode === "list" ? 1 : 0}
-        virtualOverscan={viewMode === "list" ? 18 : 10}
         jsonBase={jsonBase}
         range={range as any}
         readFilter={readFilter}

--- a/components/post-grid.tsx
+++ b/components/post-grid.tsx
@@ -28,9 +28,6 @@ interface PostGridProps {
   listColumns?: 'auto-2' | '3-2-1';
   cardLayoutOverride?: 'grid' | 'list';
   threeColAt?: 'lg' | 'xl';
-  // Virtualizer + motion knobs
-  loadAheadRows?: number;
-  virtualOverscan?: number;
   readFilter?: string;
 }
 
@@ -52,8 +49,6 @@ export default function PostGrid({
   listColumns,
   cardLayoutOverride,
   threeColAt,
-  loadAheadRows,
-  virtualOverscan,
   readFilter,
 }: PostGridProps) {
   // For the "최신" section, enforce fresh mode; for both "최신" and "지금 주목" display range in the title.
@@ -136,8 +131,6 @@ export default function PostGrid({
             listColumns={listColumns}
             cardLayoutOverride={cardLayoutOverride}
             threeColAt={threeColAt}
-            loadAheadRows={loadAheadRows}
-            virtualOverscan={virtualOverscan}
             readFilter={readFilter}
           />
         </PostListProvider>

--- a/doc/ui.md
+++ b/doc/ui.md
@@ -93,3 +93,10 @@ export default function PostList() {
   );
 }
 ```
+
+## 3. InfinitePostList 가상 버퍼 계산
+
+- `components/infinite-post-list.tsx` 는 각 행의 예상 높이(`estimateRowSize`)와 현재 `window.innerHeight` 값을 기반으로 버퍼를 계산합니다.
+- `deriveVirtualBufferSizing` 헬퍼는 뷰포트의 절반(0.5 × viewport)을 픽셀 단위로 확보하도록 행 수를 산출하고, 동일한 수의 행을 앞/뒤에 대칭으로 오버스캔합니다.
+- 실제 로딩 트리거 역시 위/아래 버퍼를 모두 고려하여 데이터가 부족해지기 전에 다음 페이지를 미리 가져오므로, 사용자는 최소한 반 화면 분량의 콘텐츠가 항상 사전 로드된 상태를 유지하게 됩니다.
+- 별도의 `virtualOverscan`/`loadAheadRows` 값을 넘기지 않으면 위의 규칙이 기본 동작이므로, 커스텀 튜닝이 필요한 경우에만 override 값을 전달하면 됩니다.


### PR DESCRIPTION
## Summary
- derive virtual list overscan from the estimated row height and half the viewport using a shared helper
- adjust InfinitePostList to update load triggers, anchor buffers, and debug metadata with the derived metrics
- remove manual overscan/load-ahead props from PostGrid callers and document the new 0.5 viewport warmup behaviour

## Testing
- pnpm lint *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d03d32dab883319c8cac2984d6ee78