### PR TITLE
Reset cache when infinite feed section changes

### DIFF
--- a/context/post-cache-context.tsx
+++ b/context/post-cache-context.tsx
@@ -6,6 +6,7 @@ import type { Post } from '@/lib/types';
 interface PostCacheContextType {
   posts: Map<string, Post>;
   addPosts: (posts: Post[]) => void;
+  replacePosts: (posts: Post[]) => void;
 }
 
 const PostCacheContext = createContext<PostCacheContextType | undefined>(undefined);
@@ -23,8 +24,18 @@ export function PostCacheProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  const replacePosts = useCallback((newPosts: Post[]) => {
+    setPosts(() => {
+      const next = new Map<string, Post>();
+      newPosts.forEach(post => {
+        next.set(post.id, post);
+      });
+      return next;
+    });
+  }, []);
+
   return (
-    <PostCacheContext.Provider value={{ posts, addPosts }}>
+    <PostCacheContext.Provider value={{ posts, addPosts, replacePosts }}>
       {children}
     </PostCacheContext.Provider>
   );


### PR DESCRIPTION
## Summary
- seed the post cache with initial section data and reset local pagination state when the feed base changes
- guard loadMore so it only writes newly collected posts into the cache
- add a replacePosts helper to the post cache context for clearing stale entries

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0492fb0fc8331887d1b7e1ab2b656