### PR TITLE
Keep active hover previews mounted

### DIFF
--- a/lib/preview-activation-store.ts
+++ b/lib/preview-activation-store.ts
@@ -1,0 +1,45 @@
+const activePreviewIds = new Set<string>();
+
+export type PreviewActivationListener = (ids: ReadonlySet<string>) => void;
+
+const listeners = new Set<PreviewActivationListener>();
+
+function emit() {
+  const snapshot = new Set(activePreviewIds);
+  for (const listener of listeners) {
+    try {
+      listener(snapshot);
+    } catch {
+      // Ignore listener errors so one subscriber cannot break others.
+    }
+  }
+}
+
+export function markPreviewActive(id: string | null | undefined) {
+  if (!id) return;
+  if (activePreviewIds.has(id)) return;
+  activePreviewIds.add(id);
+  emit();
+}
+
+export function markPreviewInactive(id: string | null | undefined) {
+  if (!id) return;
+  if (!activePreviewIds.delete(id)) return;
+  emit();
+}
+
+export function getActivePreviewIdsSnapshot(): ReadonlySet<string> {
+  return new Set(activePreviewIds);
+}
+
+export function subscribeToPreviewActivations(listener: PreviewActivationListener) {
+  listeners.add(listener);
+  try {
+    listener(new Set(activePreviewIds));
+  } catch {
+    // Ignore listener errors during initial notification.
+  }
+  return () => {
+    listeners.delete(listener);
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared hover preview activation store so cards can mark previews active or inactive
- teach the post card hover media to report activation reasons and notify the store while hover cards forward their open state
- subscribe the virtualized list to active previews and extend the range extractor so activated rows stay mounted until released

## Testing
- pnpm lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d05671d738833193d609adaf64e4ef