### PR TITLE
Fix sports category alias

### DIFF
--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1244,7 +1244,7 @@ export async function getPostsByCategory(
     'news': ['news', '뉴스'], 'humor': ['humor', '유머'], 'info': ['info', '정보'],
     'qna': ['question', '질문'], 'review': ['review', '후기'], 'debate': ['debate', '토론'],
     'back': ['back', '후방'], 'zzal': ['zzal', '짤'], 'politics': ['politics', '정치'],
-    'shopping': ['shopping', '쇼핑'], 'etc': ['etc', '기타'],
+    'shopping': ['shopping', '쇼핑'], 'etc': ['etc', '기타'], 'sports': ['sports', 'sport', '스포츠'],
   };
   const tokens = aliasMap[base] ?? [base];
   const likeTokens = tokens.map(t => `${t}%`);


### PR DESCRIPTION
## Summary
- include the sports category slug aliases in the category query mapping so that Korean and singular values are matched when filtering posts

## Testing
- pnpm lint *(fails: pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d05ebdf2b08331b47b17defe5b9b88