### PR TITLE
Enhance sidebar stats drift

### DIFF
--- a/components/sidebar-stats.client.tsx
+++ b/components/sidebar-stats.client.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import * as React from "react";
+
+import { CountingNumber } from "@/components/animate-ui/text/counting-number";
+
+const driftSpring = { stiffness: 28, damping: 160 };
+
+const MIN_FORCE_PULSE_MS = 45_000;
+
+export type SidebarStat = {
+  current: number;
+  previous: number;
+  ratePerMinute: number;
+};
+
+export type SidebarStatsSnapshot = {
+  posts: SidebarStat;
+  comments: SidebarStat;
+  activeUsers: SidebarStat;
+};
+
+type SidebarStatsProps = {
+  stats: SidebarStatsSnapshot;
+};
+
+export function SidebarStats({ stats }: SidebarStatsProps) {
+  return (
+    <div className="space-y-3 text-sm">
+      <StatisticLine label="총 게시글" stat={stats.posts} />
+      <StatisticLine label="총 댓글" stat={stats.comments} />
+      <StatisticLine label="활성 사용자" stat={stats.activeUsers} />
+    </div>
+  );
+}
+
+type StatisticLineProps = {
+  label: string;
+  stat: SidebarStat;
+};
+
+function StatisticLine({ label, stat }: StatisticLineProps) {
+  const displayValue = useDriftingValue(stat);
+
+  return (
+    <div className="flex justify-between">
+      <span className="text-gray-600">{label}</span>
+      <span className="font-medium tabular-nums">
+        <CountingNumber
+          fromNumber={stat.current}
+          number={displayValue}
+          transition={driftSpring}
+        />
+      </span>
+    </div>
+  );
+}
+
+function useDriftingValue(stat: SidebarStat) {
+  const { current, previous, ratePerMinute } = stat;
+  const [displayValue, setDisplayValue] = React.useState(current);
+  const residualRef = React.useRef(0);
+  const lastBumpRef = React.useRef<number>(Date.now());
+
+  const effectiveRate = React.useMemo(() => {
+    const safeRate = Number.isFinite(ratePerMinute) ? Math.max(0, ratePerMinute) : 0;
+    const momentumRate = Math.max(0, current - previous) / 30;
+    const volumeHint = Math.max(0.35, Math.log10(current + 10) * 0.32);
+
+    return Math.max(safeRate, momentumRate, volumeHint);
+  }, [current, previous, ratePerMinute]);
+
+  React.useEffect(() => {
+    setDisplayValue(current);
+    residualRef.current = 0;
+    lastBumpRef.current = Date.now();
+  }, [current]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const scheduleNext = () => {
+      if (cancelled) return;
+      const interval = computeNextIntervalMs(effectiveRate);
+
+      timeoutId = setTimeout(() => {
+        if (cancelled) return;
+
+        const addition = computeAddition(effectiveRate, interval, current, previous);
+
+        setDisplayValue((prev) => {
+          let nextValue = prev;
+          let applied = 0;
+          const total = residualRef.current + addition;
+
+          if (total >= 1) {
+            applied = Math.floor(total);
+            residualRef.current = total - applied;
+          } else {
+            const now = Date.now();
+            const overdue = now - lastBumpRef.current > MIN_FORCE_PULSE_MS;
+            const shouldPulse = overdue || Math.random() < total;
+
+            if (shouldPulse) {
+              applied = 1;
+              residualRef.current = Math.max(0, total - 1);
+            } else {
+              residualRef.current = total;
+            }
+          }
+
+          if (applied > 0) {
+            lastBumpRef.current = Date.now();
+            nextValue = prev + applied;
+          }
+
+          return nextValue;
+        });
+
+        scheduleNext();
+      }, interval);
+    };
+
+    scheduleNext();
+
+    return () => {
+      cancelled = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [effectiveRate, current, previous]);
+
+  return displayValue;
+}
+
+function computeNextIntervalMs(rate: number) {
+  const clamped = Math.min(Math.max(rate, 0), 12);
+  const normalized = clamped / 12; // 0 ~ 1
+  const maxInterval = 13_500;
+  const minInterval = 4_500;
+  const base = maxInterval - (maxInterval - minInterval) * normalized;
+  const jitter = base * (0.18 + Math.random() * 0.22);
+
+  return Math.max(minInterval * 0.6, base * 0.78 + jitter);
+}
+
+function computeAddition(
+  rate: number,
+  intervalMs: number,
+  current: number,
+  previous: number,
+) {
+  const intervalMinutes = intervalMs / 60_000;
+  const momentum = Math.max(0, current - previous) / 30;
+  const base = Math.max(0, rate) * intervalMinutes;
+  const momentumBoost = momentum * intervalMinutes * 0.65;
+  const noise = base * (Math.random() * 0.6 - 0.25);
+  const softFloor = base * 0.35;
+
+  return Math.max(softFloor, base + momentumBoost + noise);
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,23 +2,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { TrendingUp, Filter } from "lucide-react";
 import { getTrendingKeywords, getHomeStats24h } from "@/lib/queries";
 import { CategoryList } from "./category-list.client";
-import { CountingNumber } from "@/components/animate-ui/text/counting-number";
 import { TrendingKeywordList } from "./TrendingKeywordList.client";
 import { ReadPostList } from "./ReadPostList.client";
+import { SidebarStats } from "./sidebar-stats.client";
 
 export const dynamic = "force-static";
 export const revalidate = false;
-
-// 약 20분 동안 서서히 움직이도록 하는 목표값 (30분 속도 기반, 약간의 여유 포함)
-function projectToLongDrift(current: number, previous: number) {
-  const recent = Math.max(0, current - previous); // 30분 증가량
-  const delta10m = Math.max(1, Math.round(recent / 3)); // 10분 환산
-  const slack = Math.ceil(delta10m * 1.5); // 10분 목표에 여유를 더해 ~20분까지 움직임 유지
-  return current + Math.max(2, slack); // 최소 +2로 미세변화 보장
-}
-
-// 약 20분 스케일로 매우 천천히 수렴하게 하는 스프링 값
-const twentyMinuteSpring = { stiffness: 3, damping: 120 };
 
 export async function Sidebar() {
   const trendingKeywords = await getTrendingKeywords("24h");
@@ -31,9 +20,6 @@ export async function Sidebar() {
     hour: "2-digit",
     minute: "2-digit",
   });
-
-  // Spring options for a slow, 10-minute-like animation.
-  const slowSpring = { stiffness: 15, damping: 80 };
 
   return (
     <div className="space-y-6">
@@ -67,41 +53,12 @@ export async function Sidebar() {
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-lg">오늘의 통계</CardTitle>
-          <div className="text-xs text-gray-500">지난 24시간 내 · 빌드 {builtLabel} · 다음 빌드까지 서서히 수렴</div>
+          <div className="text-xs text-gray-500">
+            지난 24시간 내 · 빌드 {builtLabel} · 다음 빌드 전까지 숨 쉬듯 증가
+          </div>
         </CardHeader>
         <CardContent>
-          <div className="space-y-3 text-sm">
-            <div className="flex justify-between">
-              <span className="text-gray-600">총 게시글</span>
-              <span className="font-medium">
-                <CountingNumber
-                  fromNumber={stats.posts.current}
-                  number={projectToLongDrift(stats.posts.current, stats.posts.previous)}
-                  transition={twentyMinuteSpring}
-                />
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-gray-600">총 댓글</span>
-              <span className="font-medium">
-                <CountingNumber
-                  fromNumber={stats.comments.current}
-                  number={projectToLongDrift(stats.comments.current, stats.comments.previous)}
-                  transition={twentyMinuteSpring}
-                />
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-gray-600">활성 사용자</span>
-              <span className="font-medium">
-                <CountingNumber
-                  fromNumber={stats.activeUsers.current}
-                  number={projectToLongDrift(stats.activeUsers.current, stats.activeUsers.previous)}
-                  transition={twentyMinuteSpring}
-                />
-              </span>
-            </div>
-          </div>
+          <SidebarStats stats={stats} />
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
- replace the sidebar total counters with a client component that keeps values breathing between static rebuilds
- derive a soft real-time drift from 24h counts and 30m rates so the numbers continue to climb plausibly
- update the helper copy to explain the gentle increase until the next build

## Testing
- pnpm lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d05ff8318c83318a7f841c95a30f63