### PR TITLE
Support automatic window scroll margin for infinite list

### DIFF
--- a/components/post-grid.tsx
+++ b/components/post-grid.tsx
@@ -75,6 +75,11 @@ export default function PostGrid({
     : undefined;
   // Make restoration keys distinct per section/mode/range to avoid bleed across range changes
   const storageKey = `${title} [${defaultSection}|${effectiveRange}]`;
+  const shouldAutoWindowScrollMargin = Boolean(
+    enablePaging &&
+    isLatestTimeline &&
+    (base?.startsWith('/data/home/v1/') ?? false)
+  );
   console.log(`11111 [${defaultSection}|${effectiveRange}] ${title}`)
   return (
     <div className="space-y-4">
@@ -132,6 +137,7 @@ export default function PostGrid({
             cardLayoutOverride={cardLayoutOverride}
             threeColAt={threeColAt}
             readFilter={readFilter}
+            windowScrollMargin={shouldAutoWindowScrollMargin ? 'auto' : undefined}
           />
         </PostListProvider>
       )}


### PR DESCRIPTION
## Summary
- add an optional windowScrollMargin prop to the infinite post list that can auto-measure the list offset
- feed the derived scroll margin into the window virtualizer and remeasure when the value changes
- enable the auto scroll margin for the home 최신 feed when paging is active

## Testing
- pnpm lint *(fails: pre-existing lint errors across the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d08fab67e08331b3a7bee413842dfb