### PR TITLE
Adjust ranked candidates to use activity windows

### DIFF
--- a/lib/__tests__/ranked-query.test.ts
+++ b/lib/__tests__/ranked-query.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const queriesSource = readFileSync(path.join(process.cwd(), "lib", "queries.ts"), "utf8");
+
+test("ranked candidates query filters by activity window", () => {
+  assert.match(
+    queriesSource,
+    /a\.window_end\s*>=\s*NOW\(\)\s*-\s*INTERVAL '\$\{sql\.raw\(intervalLiteral\)\}'/,
+    "expected window_end based recency filter",
+  );
+});
+
+test("ranked candidates query no longer filters by post timestamp", () => {
+  assert.ok(
+    !/AND\s+p\.timestamp\s*>=\s*NOW\(\)\s*-\s*INTERVAL '\$\{sql\.raw\(intervalLiteral\)\}'/.test(queriesSource),
+    "post timestamp based filter should be removed from ranked candidates CTE",
+  );
+});
+
+test("ranked candidates query decays by activity timestamp", () => {
+  assert.match(
+    queriesSource,
+    /NOW\(\)\s*-\s*z\.activity_ts/,
+    "recency decay should use activity timestamp",
+  );
+});

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "build:category:shopping": "tsx scripts/build-category-json.ts shopping",
     "build:category:etc": "tsx scripts/build-category-json.ts etc",
     "build:category:all": "tsx scripts/build-category-json.ts all",
-    "build:categories": "pnpm build:category:news && pnpm build:category:humor && pnpm build:category:video && pnpm build:category:youtube && pnpm build:category:info && pnpm build:category:qna && pnpm build:category:review && pnpm build:category:debate && pnpm build:category:back && pnpm build:category:zzal && pnpm build:category:politics && pnpm build:category:shopping && pnpm build:category:etc && pnpm build:category:all"
+    "build:categories": "pnpm build:category:news && pnpm build:category:humor && pnpm build:category:video && pnpm build:category:youtube && pnpm build:category:info && pnpm build:category:qna && pnpm build:category:review && pnpm build:category:debate && pnpm build:category:back && pnpm build:category:zzal && pnpm build:category:politics && pnpm build:category:shopping && pnpm build:category:etc && pnpm build:category:all",
+    "test": "tsx --test"
   },
   "dependencies": {
     "@clerk/clerk-react": "^5.47.0",


### PR DESCRIPTION
## Summary
- build the ranked candidate CTE around mv_post_trends_agg.window_end so older but active posts stay eligible
- base the decay term on the activity window timestamp instead of post creation time
- add lightweight tests that verify the SQL uses activity timestamps and update package.json with a test script

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d09907437c833199043f4ef3b3fe97