### PR TITLE
Record cluster rotation for issue feeds

### DIFF
--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1070,6 +1070,17 @@ export async function getClusterTopPosts({
   const ids = picked.map((r: any) => r.id);
   if (ids.length === 0) return [];
 
+  const clusterSelections = picked
+    .filter((r: any) => r.clusterId)
+    .map((r: any) => ({
+      clusterId: r.clusterId,
+      score: r.score ?? 0,
+    }));
+  const postSelections = picked.map((r: any) => ({ id: r.id, score: r.score ?? 0 }));
+
+  await recordClusterRotation(range, clusterSelections);
+  await recordPostRotation(range, postSelections);
+
   const hydrated = await hydratePosts(ids);
   const hmap = new Map(hydrated.map((h: any) => [h.id, h]));
   return picked.map((p: any) => ({


### PR DESCRIPTION
## Summary
- record cluster selection metadata when assembling cluster top posts so rotations can be tracked
- persist both cluster and post rotation entries for the issue/weekly feeds before returning results

## Testing
- pnpm lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d09c07cb608331a00cc699beef9e84