### PR TITLE
Make modal post title link to full post

### DIFF
--- a/components/post-detail.tsx
+++ b/components/post-detail.tsx
@@ -460,7 +460,16 @@ export function PostDetail({ post, inDialog }: PostDetailProps) {
           </div>
 
           <h1 className="text-2xl md:text-3xl font-bold text-gray-900 leading-tight">
-            {post.title}
+            {inDialog ? (
+              <Link
+                href={`/posts/${post.id}`}
+                className="hover:underline"
+              >
+                {post.title}
+              </Link>
+            ) : (
+              post.title
+            )}
           </h1>
 
           <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- wrap the modal post title in a Link so preview users can open the full post page

## Testing
- pnpm lint *(fails: existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a05fe76c8331b014e33e4a532a74