### PR TITLE
Fix section key wiring in virtualized feed

### DIFF
--- a/components/category-feed.tsx
+++ b/components/category-feed.tsx
@@ -2,7 +2,7 @@ import InfinitePostList from "@/components/infinite-post-list";
 import type { Post } from "@/lib/types";
 import { PostListProvider } from "@/context/post-list-context";
 import { usePostCache } from "@/context/post-cache-context";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 interface CategoryFeedProps {
   title: string;
@@ -15,11 +15,17 @@ export default function CategoryFeed({
   category,
   initialPosts,
 }: CategoryFeedProps) {
-  const { addPosts } = usePostCache();
+  const { addPostsToSection } = usePostCache();
+  const jsonBase = useMemo(() => `/data/category/${category}/v1`, [category]);
+  const storageKeyPrefix = useMemo(() => `category-${category}`, [category]);
+  const sectionKey = useMemo(
+    () => `${jsonBase}|${storageKeyPrefix}`,
+    [jsonBase, storageKeyPrefix],
+  );
 
   useEffect(() => {
-    addPosts(initialPosts);
-  }, [initialPosts, addPosts]);
+    addPostsToSection(sectionKey, initialPosts);
+  }, [addPostsToSection, initialPosts, sectionKey]);
 
   return (
     <div className="space-y-4">
@@ -28,8 +34,8 @@ export default function CategoryFeed({
         <InfinitePostList
           initialPosts={initialPosts}
           layout="list"
-          jsonBase={`/data/category/${category}/v1`}
-          storageKeyPrefix={`category-${category}`}
+          jsonBase={jsonBase}
+          storageKeyPrefix={storageKeyPrefix}
           enablePaging={true}
         />
       </PostListProvider>

--- a/components/infinite-post-list.tsx
+++ b/components/infinite-post-list.tsx
@@ -420,6 +420,7 @@ interface ListVirtualizedFeedProps {
   layout: 'list' | 'grid';
   cardLayoutOverride?: 'grid' | 'list';
   readPostIds: ReadonlySet<string>;
+  sectionKey: string;
   listColumns: 'auto-2' | '3-2-1';
   threeColAt: 'lg' | 'xl';
   virtualOverscanOverride?: number;
@@ -453,6 +454,7 @@ function ListVirtualizedFeed({
   layout,
   cardLayoutOverride,
   readPostIds,
+  sectionKey,
   listColumns,
   threeColAt,
   virtualOverscanOverride,
@@ -1067,6 +1069,7 @@ function ListVirtualizedFeed({
                         layout={cardLayoutOverride ?? layout}
                         page={postIdToPageNumRef.current.get(post.id) || initialPage}
                         storageKeyPrefix={storageKeyPrefix}
+                        sectionKey={sectionKey}
                         isNew={(start + i) >= initialPosts.length}
                         isPriority={(start + i) < 5}
                         isRead={readPostIds.has(post.id)}
@@ -1159,7 +1162,7 @@ export default function InfinitePostList({
   readFilter = 'all',
   windowScrollMargin: windowScrollMarginProp = 0,
 }: InfinitePostListProps) {
-  const { addPosts, replacePosts } = usePostCache();
+  const { addPostsToSection, replacePostsForSection } = usePostCache();
   const searchParams = useSearchParams();
   // --- Column change observer (for grid layout) ---
   const prevColsRef = useRef<number>(0);
@@ -1287,7 +1290,7 @@ export default function InfinitePostList({
   );
 
   useEffect(() => {
-    replacePosts(initialPosts);
+    replacePostsForSection(sectionKey, initialPosts);
 
     const prevKey = prevSectionKeyRef.current;
     if (prevKey === sectionKey) {
@@ -1338,7 +1341,7 @@ export default function InfinitePostList({
     initialPage,
     initialPosts,
     jsonBase,
-    replacePosts,
+    replacePostsForSection,
     sectionKey,
   ]);
 
@@ -1667,7 +1670,7 @@ export default function InfinitePostList({
     }
     dlog("loadMore:loop-end", { appendedCount, lastSuccessfulPage, prevPage: pageRef.current });
     if (collected.length > 0) {
-      addPosts(collected);
+      addPostsToSection(sectionKey, collected);
       // Commit visibility before rendering
       collectedPairs.forEach(({ post, pageNum }) => {
         seenIdsRef.current.add(post.id);
@@ -1718,7 +1721,7 @@ export default function InfinitePostList({
     } catch {
       // no-op
     }
-  }, [loadPage, addPosts, jsonBase, maybeRefreshManifest]);
+  }, [loadPage, addPostsToSection, jsonBase, maybeRefreshManifest, sectionKey]);
 
   const ensureBelowBufferRows = useCallback(async (anchorId: string) => {
     const metrics = bufferMetricsRef.current;
@@ -1918,6 +1921,7 @@ export default function InfinitePostList({
         visiblePosts={visiblePosts}
         layout={layout}
         cardLayoutOverride={cardLayoutOverride}
+        sectionKey={sectionKey}
         listColumns={listColumns}
         threeColAt={threeColAt}
         virtualOverscanOverride={virtualOverscan}
@@ -2003,6 +2007,7 @@ export default function InfinitePostList({
               layout={layout}
               page={postIdToPageNumRef.current.get(post.id) || initialPage}
               storageKeyPrefix={storageKeyPrefix}
+              sectionKey={sectionKey}
               isNew={index >= initialPosts.length}
               isPriority={index < 10}
               isRead={readPostIds.has(post.id)}

--- a/components/post-card.tsx
+++ b/components/post-card.tsx
@@ -698,6 +698,7 @@ interface PostCardProps {
   layout: "list" | "grid";
   page?: number;
   storageKeyPrefix?: string;
+  sectionKey: string;
   isNew?: boolean;
   isPriority?: boolean;
   isRead?: boolean;
@@ -715,10 +716,10 @@ const communityColors: Record<string, string> = {
 };
 
 export const PostCard = React.memo(
-  function PostCard({ postId, layout, page, storageKeyPrefix = "", isNew = false, isPriority = false, isRead = false }: PostCardProps) {
+  function PostCard({ postId, layout, page, storageKeyPrefix = "", sectionKey, isNew = false, isPriority = false, isRead = false }: PostCardProps) {
     const { openModal } = useModal();
     const { postIds } = usePostList();
-    const { posts } = usePostCache();
+    const { posts } = usePostCache(sectionKey);
     const post = posts.get(postId) as Post;
     const { setReasonActive: setPreviewActivationReason } = usePreviewActivationTracker(postId);
     const handleHoverCardOpenChange = React.useCallback(


### PR DESCRIPTION
## Summary
- pass the section cache key through ListVirtualizedFeed props so cards render with the correct cache slice

## Testing
- pnpm lint *(fails: existing @typescript-eslint/no-explicit-any and other lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d95c7558833191820c12bddcec4c