### PR TITLE
Switch trending keywords sidebar to 6-hour window

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -10,7 +10,7 @@ export const dynamic = "force-static";
 export const revalidate = false;
 
 export async function Sidebar() {
-  const trendingKeywords = await getTrendingKeywords("24h");
+  const trendingKeywords = await getTrendingKeywords("6h");
   const stats = await getHomeStats24h(); // `previous` is now `current - recent_additions`
 
   const builtLabel = new Date().toLocaleString("ko-KR", {
@@ -30,6 +30,7 @@ export async function Sidebar() {
             <TrendingUp className="h-5 w-5" />
             실시간 인기 키워드
           </CardTitle>
+          <div className="text-xs text-gray-500">최근 6시간 기준</div>
         </CardHeader>
         <CardContent>
           <TrendingKeywordList keywords={trendingKeywords} />

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1170,7 +1170,7 @@ export async function getHomeStats24h() {
   }
 }
 
-export async function getTrendingKeywords(range: "3h" | "6h" | "24h" | "1w" = "24h") {
+export async function getTrendingKeywords(range: "3h" | "6h" | "24h" | "1w" = "6h") {
   const latestWindowSubquery = db
     .select({ value: sql`MAX(${keywordTrends.windowEnd})` })
     .from(keywordTrends)


### PR DESCRIPTION
## Summary
- pull trending keyword data using the 6-hour aggregation window by default
- communicate the 6-hour basis in the sidebar trending keyword card

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0db58201c833194bce9dada7e7ee5