### PR TITLE
Adjust home feed dedupe for sampled sections

### DIFF
--- a/components/client-random-clamp.tsx
+++ b/components/client-random-clamp.tsx
@@ -40,7 +40,17 @@ function pickRandom<T>(arr: T[], k: number, seed: number) {
 }
 
 export default function ClientRandomClamp({
-    items, sampleMax, layout = "grid", community, jsonBase, storageKeyPrefix, seedIntervalMs = 120000, rows = 1, randomizeOnEachMount = false,
+    items,
+    sampleMax,
+    layout = "grid",
+    community,
+    jsonBase,
+    storageKeyPrefix,
+    seedIntervalMs = 120000,
+    rows = 1,
+    randomizeOnEachMount = false,
+    initialSampled,
+    initialSeed,
 }: {
     items: any[];
     sampleMax: number;
@@ -55,6 +65,8 @@ export default function ClientRandomClamp({
      * (페이지 새로고침마다 구성이 달라짐)
      */
     randomizeOnEachMount?: boolean;
+    initialSampled?: any[];
+    initialSeed?: number;
 }) {
     const measureRef = useRef<HTMLDivElement | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
@@ -70,12 +82,22 @@ export default function ClientRandomClamp({
     // 씨드 계산
     // - randomizeOnEachMount: 마운트마다 고정된 난수 씨드
     // - 아니면 시간 버킷 씨드(예: seedIntervalMs 단위로 바뀜; 새로고침 기준)
-    const seedRef = useRef<number>(Math.floor(Math.random() * 1e9));
-    const seed = useMemo(
-        () => (randomizeOnEachMount ? seedRef.current : Math.floor(Date.now() / seedIntervalMs)),
-        [randomizeOnEachMount, seedIntervalMs]
-    );
-    const sampled = useMemo(() => pickRandom(items, sampleMax, seed), [items, sampleMax, seed]);
+    const seedRef = useRef<number>(initialSeed ?? Math.floor(Math.random() * 1e9));
+    const seed = useMemo(() => {
+        if (randomizeOnEachMount) {
+            return seedRef.current;
+        }
+        if (initialSeed != null) {
+            return initialSeed;
+        }
+        return Math.floor(Date.now() / seedIntervalMs);
+    }, [initialSeed, randomizeOnEachMount, seedIntervalMs]);
+    const sampled = useMemo(() => {
+        if (initialSampled && initialSampled.length > 0) {
+            return initialSampled;
+        }
+        return pickRandom(items, sampleMax, seed);
+    }, [initialSampled, items, sampleMax, seed]);
 
     // 🔍 디버깅용 로그
     useEffect(() => {
@@ -86,8 +108,9 @@ export default function ClientRandomClamp({
             readyCols: cols || measuredCols,
             seed,
             randomizeOnEachMount,
+            initialSeed,
         });
-    }, [items, sampleMax, sampled, cols, measuredCols, seed, randomizeOnEachMount]);
+    }, [items, sampleMax, sampled, cols, measuredCols, seed, randomizeOnEachMount, initialSeed]);
 
     useEffect(() => {
         const el = measureRef.current;

--- a/components/post-grid.tsx
+++ b/components/post-grid.tsx
@@ -16,6 +16,8 @@ interface PostGridProps {
    * (섹션 간 중복 제거 및 차별화 목적)
    */
   initialPosts?: any[];
+  initialSampledPosts?: any[];
+  clampSeed?: number;
   jsonBase?: string;
   enablePaging?: boolean;
   community?: string;
@@ -38,6 +40,8 @@ export default function PostGrid({
   layout = "grid",
   mode = "ranked",
   initialPosts,
+  initialSampledPosts,
+  clampSeed,
   jsonBase,
   enablePaging = true,
   community,
@@ -118,6 +122,8 @@ export default function PostGrid({
           storageKeyPrefix={storageKey}
           rows={rows}
           randomizeOnEachMount={!!randomizeOnEachMount}
+          initialSampled={initialSampledPosts}
+          initialSeed={clampSeed}
         />
       ) : (
         <PostListProvider postIds={mapped.map(p => p.id)}>

--- a/lib/server-random-clamp.ts
+++ b/lib/server-random-clamp.ts
@@ -1,0 +1,47 @@
+const DEFAULT_SEED_INTERVAL_MS = 120_000;
+
+function mulberry32(seed: number) {
+  return function () {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pickRandom<T>(arr: T[], k: number, seed: number) {
+  const a = arr.slice();
+  const rand = mulberry32(seed);
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a.slice(0, Math.min(k, a.length));
+}
+
+export interface ServerClampOptions {
+  sampleMax: number;
+  randomizeOnEachMount?: boolean;
+  seedIntervalMs?: number;
+  seed?: number;
+}
+
+export interface ServerClampResult<T> {
+  sampled: T[];
+  seed: number;
+}
+
+export function sampleForClamp<T>(items: T[], options: ServerClampOptions): ServerClampResult<T> {
+  const { sampleMax, randomizeOnEachMount = false, seedIntervalMs = DEFAULT_SEED_INTERVAL_MS, seed } = options;
+
+  if (!Array.isArray(items) || items.length === 0 || sampleMax <= 0) {
+    return { sampled: [], seed: seed ?? 0 };
+  }
+
+  const effectiveSeed =
+    seed ?? (randomizeOnEachMount ? Math.floor(Math.random() * 1e9) : Math.floor(Date.now() / seedIntervalMs));
+
+  const sampled = pickRandom(items, sampleMax, effectiveSeed);
+
+  return { sampled, seed: effectiveSeed };
+}


### PR DESCRIPTION
## Summary
- add a server-side clamp sampler so the home page knows which random cards are rendered
- only add the sampled "급상승"/"지금 주목" posts to the exclusion set while passing their sample/seed to the UI
- extend the client clamp component and PostGrid to accept pre-sampled data so sections stay in sync with server dedupe

## Testing
- pnpm lint *(fails: existing repository eslint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ebbe5dec83319b614e2a143e4cc2